### PR TITLE
Add native support for GitHub & GitLab secret tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # git-deploy
 
-A PHP script to automatically pull from a repository to a web server (using a webhook on GitLab, GitHub or Bitbucket).
+A PHP script to automatically pull from a repository to a web server (using a webhook on GitHub, GitLab, or Bitbucket).
 
 You can configure which branch this script pulls from. This script is useful for both development and production servers.
 

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ Copy the __git-deploy__ folder and its contents in to your public folder (typica
 Rename __git-deploy/config.sample.php__ to __git-deploy/config.php__, and update each variable to a value that suits your needs. An example of a live configuration is below.
 
 ```PHP
-    define("TOKEN", "secret-token");
-    define("REMOTE_REPOSITORY", "git@github.com:username/custom-project.git");
-    define("DIR", "/var/www/vhosts/repositories/custom-project");
-    define("BRANCH", "refs/heads/master");
-    define("LOGFILE", "deploy.log");
-    define("GIT", "/usr/bin/git");
-    define("AFTER_PULL", "/usr/bin/node ./node_modules/gulp/bin/gulp.js default");
+define("TOKEN", "secret-token");
+define("REMOTE_REPOSITORY", "git@github.com:username/custom-project.git");
+define("DIR", "/var/www/vhosts/repositories/custom-project");
+define("BRANCH", "refs/heads/master");
+define("LOGFILE", "deploy.log");
+define("GIT", "/usr/bin/git");
+define("AFTER_PULL", "/usr/bin/node ./node_modules/gulp/bin/gulp.js default");
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,13 +20,16 @@ Generate an SSH key and add it to your account so that `git pull` can be run wit
 
 Copy the __git-deploy__ folder and its contents in to your public folder (typically public_html). Note that you can change the name of the folder if desired.
 
-Rename __git-deploy/config.sample.php__ to __git-deploy/config.php__, and update each variable.
+Rename __git-deploy/config.sample.php__ to __git-deploy/config.php__, and update each variable to a value that suits your needs. An example of a live configuration is below.
 
 ```PHP
-  define('TOKEN', 'your-secret-token');
-  define('REMOTE_REPOSITORY', 'your-repository');
-  define('DIR','your-absolute-path-to-git');
-  define('AFTER_PULL','your-shell-commands');
+    define("TOKEN", "secret-token");
+    define("REMOTE_REPOSITORY", "git@github.com:username/custom-project.git");
+    define("DIR", "/var/www/vhosts/repositories/custom-project");
+    define("BRANCH", "refs/heads/master");
+    define("LOGFILE", "deploy.log");
+    define("GIT", "/usr/bin/git");
+    define("AFTER_PULL", "/usr/bin/node ./node_modules/gulp/bin/gulp.js default");
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In your repository, navigate to Settings &rarr; Webhooks &rarr; Add webhook, and
 
 Click "Add webhook" to save your settings, and the script should start working.
 
-![Example screenshot showing GitHub webhook settings](https://cloud.githubusercontent.com/assets/1123997/25352059/4e38f734-28f0-11e7-8f2c-e7ca5ef153ea.png)
+![Example screenshot showing GitHub webhook settings](https://cloud.githubusercontent.com/assets/1123997/25409764/f05526d0-29d8-11e7-858d-f28de59bd300.png)
 
 ### GitLab
 
@@ -61,7 +61,7 @@ In your repository, navigate to Settings &rarr; Integrations, and use the follow
 
 Click "Add webhook" to save your settings, and the script should start working.
 
-![Example screenshot showing GitLab webhook settings](https://cloud.githubusercontent.com/assets/1123997/25352520/e76ff672-28f1-11e7-8570-112f3eec8567.png)
+![Example screenshot showing GitLab webhook settings](https://cloud.githubusercontent.com/assets/1123997/25409763/f0540a16-29d8-11e7-95d1-5570c574fde0.png)
 
 ### Bitbucket
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Generate an SSH key and add it to your account so that `git pull` can be run wit
 
 Copy the __git-deploy__ folder and its contents in to your public folder (typically public_html). Note that you can change the name of the folder if desired.
 
-Open __git-deploy/config.php__, and update each variable.
+Rename __git-deploy/config.sample.php__ to __git-deploy/config.php__, and update each variable.
 
 ```PHP
   define('TOKEN', 'your-secret-token');

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Rename __git-deploy/config.sample.php__ to __git-deploy/config.php__, and update
 
 In your repository, navigate to Settings &rarr; Webhooks &rarr; Add webhook, and use the following settings:
 
-- Payload URL: https://www.yoursite.com/git-deploy/deploy.php?token=your-secret-token
+- Payload URL: https://www.yoursite.com/git-deploy/deploy.php
 - Content type: application/json
-- Secret: blank (this script uses a token at the end of the URL as the secret)
+- Secret: The value of TOKEN in config.php
 - Which events would you like to trigger this webhook?: :radio_button: Just the push event
 - Active: :ballot_box_with_check:
 
@@ -54,8 +54,8 @@ Click "Add webhook" to save your settings, and the script should start working.
 
 In your repository, navigate to Settings &rarr; Integrations, and use the following settings:
 
-- URL: https://www.yoursite.com/git-deploy/deploy.php?token=your-secret-token
-- Secret Token: blank (this script uses a token at the end of the URL as the secret token)
+- URL: https://www.yoursite.com/git-deploy/deploy.php
+- Secret Token: The value of TOKEN in config.php
 - Trigger: :ballot_box_with_check: Push events
 - Enable SSL verification: :ballot_box_with_check: (only if using SSL, see [GitLab's documentation](https://gitlab.com/help/user/project/integrations/webhooks#ssl-verification) for more details)
 
@@ -68,7 +68,7 @@ Click "Add webhook" to save your settings, and the script should start working.
 In your repository, navigate to Settings &rarr; Webhooks &rarr; Add webhook, and use the following settings:
 
 - Title: git-deploy
-- URL: https://www.yoursite.com/git-deploy/deploy.php?token=your-secret-token
+- URL: https://www.yoursite.com/git-deploy/deploy.php?token=secret-token
 - Active: :ballot_box_with_check:
 - SSL / TLS: :white_large_square: Skip certificate verification (only if using SSL, see [Bitbucket's documentation](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#ManageWebhooks-skip_certificate) for more details)
 - Triggers: :radio_button: Repository push

--- a/config.sample.php
+++ b/config.sample.php
@@ -1,8 +1,8 @@
 <?php
-define('TOKEN', 'secret-token'); // This TOKEN put in Payload URL in GitLab or GitHub, Example: http://mydomain.com/deploy.php?token=mytoken
-define('REMOTE_REPOSITORY', 'git@gitlab.com:HelloWorld.git');
-define('DIR','/var/www/vhosts/HelloWordRepo/'); // It's important that the path ends with '/'
-define('BRANCH','refs/heads/master'); // (Gitlab branch Route)
-define('LOGFILE', "log.txt"); // Log File Name
-define('GIT', '/usr/bin/git'); // Unix git command route
-define('AFTER_PULL', ''); // Command to execute after successfully pulling
+define("TOKEN", "secret-token");                                       // The secret token to add as a GitHub or GitLab secret, or otherwise as https://www.example.com/?token=secret-token
+define("REMOTE_REPOSITORY", "git@github.com:username/repository.git"); // The SSH URL to your repository
+define("DIR", "/var/www/vhosts/repository/");                          // The path to your repostiroy; this must begin with a forward slash (/)
+define("BRANCH", "refs/heads/master");                                 // The branch route
+define("LOGFILE", "deploy.log");                                       // The name of the file you want to log to.
+define("GIT", "/usr/bin/git");                                         // The path to the git executable
+define("AFTER_PULL", "");                                              // A command to execute after successfully pulling

--- a/deploy.php
+++ b/deploy.php
@@ -21,7 +21,7 @@ date_default_timezone_set("UTC");
 fputs($file, date("d-m-Y (H:i:s)", $time) . "\n");
 
 // function to forbid access
-function forbid($reason) {
+function forbid($file, $reason) {
     // explain why
     if ($reason) fputs($file, "=== ERROR: " . $reason . " ===\n");
     fputs($file, "*** ACCESS DENIED ***" . "\n\n\n");
@@ -34,16 +34,16 @@ function forbid($reason) {
 
 // Check for a GitHub signature
 if (!empty(TOKEN) && isset($_SERVER["HTTP_X_HUB_SIGNATURE"]) && $token !== hash_hmac($algo, $content, TOKEN)) {
-    forbid("X-Hub-Signature does not match TOKEN");
+    forbid($file, "X-Hub-Signature does not match TOKEN");
 // Check for a GitLab token
 } elseif (!empty(TOKEN) && isset($_SERVER["HTTP_X_GITLAB_TOKEN"]) && $token !== sha1(TOKEN)) {
-    forbid("X-GitLab-Token does not match TOKEN");
+    forbid($file, "X-GitLab-Token does not match TOKEN");
 // Check for a $_GET token
 } elseif (!empty(TOKEN) && isset($_GET["token"]) && $token !== TOKEN) {
-    forbid("\$_GET[\"token\"] does not match TOKEN");
+    forbid($file, "\$_GET[\"token\"] does not match TOKEN");
 // if none of the above match, but a token exists, exit
 } elseif (!empty(TOKEN) && !isset($_SERVER["HTTP_X_HUB_SIGNATURE"]) && !isset($_SERVER["HTTP_X_GITLAB_TOKEN"]) && !isset($_GET["token"])) {
-    forbid("No token detected");
+    forbid($file, "No token detected");
 } else {
     // check if pushed branch matches branch specified in config
     if ($json["ref"] === BRANCH) {

--- a/deploy.php
+++ b/deploy.php
@@ -6,6 +6,7 @@ $json    = json_decode($content, true);
 $file    = fopen(LOGFILE, "a");
 $time    = time();
 
+// log the time
 date_default_timezone_set("UTC");
 fputs($file, date("d-m-Y (H:i:s)", $time) . "\n");
 
@@ -42,11 +43,14 @@ if (!empty(TOKEN) && isset($_SERVER["HTTP_X_HUB_SIGNATURE"])) {
     if ($json["ref"] === BRANCH) {
         fputs($file, $content . PHP_EOL);
 
+        // ensure directory is a repository
         if (file_exists(DIR . ".git") && is_dir(DIR)) {
             try {
+                // pull
                 chdir(DIR);
                 shell_exec(GIT . " pull");
 
+                // execute AFTER_PULL if specified
                 if (!empty(AFTER_PULL)) {
                     try {
                         shell_exec(AFTER_PULL);

--- a/deploy.php
+++ b/deploy.php
@@ -1,47 +1,46 @@
 <?php
+require_once("config.php");
 
-require_once ('config.php');
+$content = file_get_contents("php://input");
+$json    = json_decode($content, true);
+$file    = fopen(LOGFILE, "a");
+$time    = time();
 
-$content = file_get_contents('php://input');
-$json = json_decode($content, true);
-$file = fopen(LOGFILE, "a"); // Name for you Log File
-$time = time();
+date_default_timezone_set("UTC");
+fputs($file, date("d-m-Y (H:i:s)", $time) . "\n");
 
-date_default_timezone_set('UTC');
-fputs($file, date("d-m-Y (H:i:s)",$time) . "\n");
+if (!isset($_GET["token"]) || $_GET["token"] !== TOKEN) {
+    header("HTTP/1.0 403 Forbidden");
+    fputs($file, "Access Denied" . "\n");
+    exit;
+} else {
+    if ($json["ref"] == BRANCH) {
+        fputs($file, $content . PHP_EOL);
 
-if (!isset($_GET['token']) || $_GET['token'] !== TOKEN) {
-	header('HTTP/1.0 403 Forbidden');
-	fputs($file, "Access Denied" . "\n");
-	exit;
-}else{
-	if($json['ref'] == BRANCH){
-		fputs($file, $content . PHP_EOL);
-		if (file_exists(DIR.'.git') && is_dir(DIR)) {
-		        try{
-	        	        chdir(DIR);
-	                	shell_exec(GIT . ' pull');
-		        		if (!empty(AFTER_PULL)) {
-                            try{
-                                shell_exec(AFTER_PULL);
-                            }catch (Exception $e) {
-                                fputs($file, $e . "\n");
-                            }
-                        }
-	                	fputs($file, "*** AUTO PULL SUCCESFUL ***" . "\n");
-	        	}catch (Exception $e) {
-	                	fputs($file, $e . "\n");
-	        	}
-		}
-		else {
-	        	fputs($file, "DIR Not Found" . "\n");
-		}
-	}
-	else{
-		fputs($file, "Push in: " . $json['ref'] . "\n");
-	}
+        if (file_exists(DIR . ".git") && is_dir(DIR)) {
+            try {
+                chdir(DIR);
+                shell_exec(GIT . " pull");
+
+                if (!empty(AFTER_PULL)) {
+                    try {
+                        shell_exec(AFTER_PULL);
+                    } catch (Exception $e) {
+                        fputs($file, $e . "\n");
+                    }
+                }
+
+                fputs($file, "*** AUTO PULL SUCCESFUL ***" . "\n");
+            } catch (Exception $e) {
+                fputs($file, $e . "\n");
+            }
+        } else {
+            fputs($file, "DIR Not Found" . "\n");
+        }
+    } else{
+        fputs($file, "Push in: " . $json["ref"] . "\n");
+    }
 }
 
 fputs($file, "\n\n" . PHP_EOL);
 fclose($file);
-?>

--- a/deploy.php
+++ b/deploy.php
@@ -9,30 +9,36 @@ $time    = time();
 date_default_timezone_set("UTC");
 fputs($file, date("d-m-Y (H:i:s)", $time) . "\n");
 
-if (!empty(TOKEN)) {
-    if (isset($_SERVER["HTTP_X_HUB_SIGNATURE"])) {
-        list($algo, $hash) = explode("=", $_SERVER["HTTP_X_HUB_SIGNATURE"], 2) + array("", "");
+// function to forbid access
+function forbid() {
+    header("HTTP/1.0 403 Forbidden");
+    fputs($file, "*** ACCESS DENIED ***" . "\n\n\n");
+    fclose($file);
+    exit;
+}
 
-        if ($hash !== hash_hmac($algo, $content, TOKEN)) {
-            header("HTTP/1.0 403 Forbidden");
-            fputs($file, "Access Denied" . "\n");
-            exit;
-        }
-    } elseif (isset($_SERVER["HTTP_X_GITLAB_TOKEN"])) {
-        if ($_SERVER["HTTP_X_GITLAB_TOKEN"] !== sha1(TOKEN)) {
-            header("HTTP/1.0 403 Forbidden");
-            fputs($file, "Access Denied" . "\n");
-            exit;
-        }
-    } elseif (isset($_GET["token"])) {
-        if ($_GET["token"] !== TOKEN) {
-            header("HTTP/1.0 403 Forbidden");
-            fputs($file, "Access Denied" . "\n");
-            exit;
-        }
+// Check for a GitHub signature
+if (!empty(TOKEN) && isset($_SERVER["HTTP_X_HUB_SIGNATURE"])) {
+    list($algo, $hash) = explode("=", $_SERVER["HTTP_X_HUB_SIGNATURE"], 2) + array("", "");
+
+    if ($hash !== hash_hmac($algo, $content, TOKEN)) {
+        forbid();
     }
+// Check for a GitLab token
+} elseif (!empty(TOKEN) && isset($_SERVER["HTTP_X_GITLAB_TOKEN"])) {
+    if ($_SERVER["HTTP_X_GITLAB_TOKEN"] !== sha1(TOKEN)) {
+        forbid();
+    }
+// Check for a $_GET token
+} elseif (!empty(TOKEN) && isset($_GET["token"])) {
+    if ($_GET["token"] !== TOKEN) {
+        forbid();
+    }
+// if none of the above match, but a token exists, exit
+} elseif (!empty(TOKEN)) {
+    forbid();
 } else {
-    if ($json["ref"] == BRANCH) {
+    if ($json["ref"] === BRANCH) {
         fputs($file, $content . PHP_EOL);
 
         if (file_exists(DIR . ".git") && is_dir(DIR)) {
@@ -53,7 +59,7 @@ if (!empty(TOKEN)) {
                 fputs($file, $e . "\n");
             }
         } else {
-            fputs($file, "DIR Not Found" . "\n");
+            fputs($file, "DIR is not a repository" . "\n");
         }
     } else{
         fputs($file, "Push in: " . $json["ref"] . "\n");


### PR DESCRIPTION
- First checks for GitHub, then for GitLab, then falls back to the original `$_GET["token"]` method.
- Update configuration documentation
- Improve log messages
- Standardize code formatting